### PR TITLE
fix: use call_module_type instead of module attribute

### DIFF
--- a/tflint.hcl
+++ b/tflint.hcl
@@ -5,7 +5,7 @@ plugin "azurerm" {
 }
 
 config {
-  module = true
+  call_module_type = "local"
   force = false
   disabled_by_default = false
 


### PR DESCRIPTION
This should fix ci/lint failures:

```
Failed to load TFLint config; module attribute was removed in v0.54.0.
Use call_module_type instea
```

Encountered for PR 
- https://github.com/claranet/terraform-azurerm-aks-light/pull/17

![image](https://github.com/user-attachments/assets/aaec5ea3-76ed-4576-8313-67c9a1f70e65)
